### PR TITLE
Project Repo should not be unique

### DIFF
--- a/sql/V202404058363__Modify_Project.sql
+++ b/sql/V202404058363__Modify_Project.sql
@@ -1,0 +1,2 @@
+ALTER TABLE [Project]
+DROP CONSTRAINT UK_Project_Repo


### PR DESCRIPTION
### This PR affects / introduces the following:
- Makes project repo not unique
- Sometimes we make abandon a project and create a new one with the same repo. Removing the constraint allows for this.

### Related Ticket: [[SCRUM-XXXX](https://release-monkey.atlassian.net/browse/SCRUM-XXXX)](https://release-monkey.atlassian.net/jira/software/projects/SCRUM/boards/1?selectedIssue=SCRUM-49)
