### PR TITLE
CLI erorrs from backend should be logged without stacktrace

### DIFF
--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -6,6 +6,18 @@ internal class Program
 {
     private static async Task Main(string[] args)
     {
+        try
+        {
+            await ParseArgs(args);
+        }
+        catch (ApiException e)
+        {
+            Console.WriteLine(e.Message);
+        }
+    }
+
+    private static async Task ParseArgs(string[] args)
+    {
         LocalPreferencesServices localPreferencesServices = new();
         ApiService apiService = new(localPreferencesServices);
         GithubService githubService = new("Iv1.2a4a99768f6b514e", 30001);
@@ -46,7 +58,7 @@ internal class Program
                     break;
                 case "project":
                     await commands.PrintProject();
-                    break;                 
+                    break;
                 case "list-projects":
                     await commands.ListProjects();
                     break;

--- a/cli/services/ApiService.cs
+++ b/cli/services/ApiService.cs
@@ -29,23 +29,29 @@ namespace cli.services
             var response = await httpClient.PostAsync(BuildUrl(path), content);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
-            if (response.StatusCode >= HttpStatusCode.OK && response.StatusCode <= HttpStatusCode.PartialContent)
+            if (response.IsSuccessStatusCode)
             {
                 return JsonSerializer.Deserialize<R>(stringResponse)!;
             }
             else
             {
-                // TODO: Do proper error reporting.
-                throw new ApiException($"{stringResponse}: Status code {response.StatusCode}");
+                throw new ApiException($"{stringResponse}: Status code {response.StatusCode}.");
             }
         }
 
         private async Task<T> Get<T>(string path) where T : class
         {
             var response = await httpClient.GetAsync(BuildUrl(path));
-            response.EnsureSuccessStatusCode();
             var stringResponse = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<T>(stringResponse)!;
+
+            if (response.IsSuccessStatusCode)
+            {
+                return JsonSerializer.Deserialize<T>(stringResponse)!;
+            }
+            else
+            {
+                throw new ApiException($"{stringResponse}: Status code {response.StatusCode}.");
+            }
         }
 
         public Task<Project> CreateProject(string projectName, string githubRepo)


### PR DESCRIPTION
### This PR affects / introduces the following:
- When backend returns non-success status codes, the cli logs a stack trace with the error message. This PR refactors the code to ensure only the error messages shows.

### Related Ticket: https://release-monkey.atlassian.net/jira/software/projects/SCRUM/boards/1?selectedIssue=SCRUM-55
