### PR TITLE
Make it possible for releases to be made from a github workflow

### DIFF
--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -46,7 +46,7 @@ internal class Program
                     break;
                 case "project":
                     await commands.PrintProject();
-                    break;                 
+                    break;
                 case "list-projects":
                     await commands.ListProjects();
                     break;
@@ -82,6 +82,19 @@ internal class Program
                     else
                     {
                         Console.WriteLine("Please provide the id of the release to approve.");
+                    }
+                    break;
+                case "release-key":
+                    await commands.PrintReleaseKey();
+                    break;
+                case "load-release-key":
+                    if (args.Length > 1)
+                    {
+                        await commands.LoadReleaseKey(args[1]);
+                    }
+                    else
+                    {
+                        Console.WriteLine("Please provide a release key to load.");
                     }
                     break;
                 case "help":

--- a/cli/models/Models.cs
+++ b/cli/models/Models.cs
@@ -7,4 +7,6 @@ namespace cli.models
     internal record Project(int Id, string Name, string Repo);
 
     internal record Release(int Id, string ReleaseName, int ProjectId);
+
+    internal record ReleaseKey(User User, Project Project);
 }


### PR DESCRIPTION
### This PR affects / introduces the following:
- Developers will automate their releases from a Github workflow. The cli should allow them to upload releases from a workflow while keeping our API secure and protected. This PR allows for that.
- Running 'release-key' command creates a base64 encoding of the currently logged in user and the project they have selected. This encoding is the release key.
- Running `load-release-key' command loads the release key and populates settings.json with the user and project in question.
- The idea is to allow the release keys to be saved in GITHUB secrets and used by workflows to access release monkey via the cli.

### Related Ticket: https://release-monkey.atlassian.net/jira/software/projects/SCRUM/boards/1?selectedIssue=SCRUM-50

![image](https://github.com/Release-Monkey/release-monkey/assets/156436448/93f08064-f779-4153-a84c-f00e31f47ffe)

