### PR TITLE
Publish with release monkey

### DIFF
--- a/.github/workflows/tagged-beta-release.yaml
+++ b/.github/workflows/tagged-beta-release.yaml
@@ -33,3 +33,16 @@ jobs:
           prerelease: true
           files: |
             cli/bin/Release/net8.0/win-x64/publish/*.exe
+
+      - name: Download rel-monkey
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/Release-Monkey/release-monkey/releases/download/latest/rel-monkey.exe" -OutFile "rel-monkey.exe"
+        
+      - name: Load Release Key
+        run: ./rel-monkey load-release-key "${{ secrets.RELEASE_KEY }}"
+
+      - name: Publish Release
+        shell: pwsh
+        run: ./rel-monkey create-release "${{ github.ref_name}}".replace("beta", "prod") "https://github.com/Release-Monkey/release-monkey/releases/tag/${{ github.ref_name}}"
+      


### PR DESCRIPTION
### This PR affects / introduces the following:
- We should use release monkey to help manage the release cycle for release monkey.

### Related Ticket: https://release-monkey.atlassian.net/jira/software/projects/SCRUM/boards/1?selectedIssue=SCRUM-56
